### PR TITLE
ADBDEV-36 Change version of gpdb

### DIFF
--- a/configure
+++ b/configure
@@ -582,8 +582,8 @@ MAKEFLAGS=
 # Identity of this package.
 PACKAGE_NAME='Greenplum Database'
 PACKAGE_TARNAME='greenplum-database'
-PACKAGE_VERSION='5.0.0'
-PACKAGE_STRING='Greenplum Database 5.0.0'
+PACKAGE_VERSION='5.9.0_arenadata2'
+PACKAGE_STRING='Greenplum Database 5.9.0_arenadata2'
 PACKAGE_BUGREPORT='support@greenplum.org'
 PACKAGE_URL=''
 


### PR DESCRIPTION
That was set previously to 5.0.0 due to troubles with madlib
It was solved in madlib 1.14, so we could change it