### PR TITLE
ADBDEV-36 Fixup module's compatibility checker

### DIFF
--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -402,7 +402,7 @@ typedef enum {
 #define PG_MODULE_MAGIC_DATA \
 { \
 	sizeof(Pg_magic_struct), \
-	GP_VERSION_NUM / 100, \
+	GP_VERSION_NUM / 10000 * 100, \
 	FUNC_MAX_ARGS, \
 	INDEX_MAX_KEYS, \
 	NAMEDATALEN, \


### PR DESCRIPTION
There is a protective code in every module and gpdb, that
compares versions inside module and gpdb. Due to legacy reasons
it compares up to second digit (5.4 != 5.2). The truth that
there is a real compatibility acros 5.x (5.x == 5.y for x,i in INT)

To achive that compatitibilty upstream stops to change version inside
gpdb (it's 5.0.0 always).

That commit changes checker logic and now it compares fist digit only.